### PR TITLE
behavior tests for tx throughput

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -94,6 +94,19 @@
         "winston": "^3.2.1"
       }
     },
+    "@holochain/tryorama-stress-utils": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@holochain/tryorama-stress-utils/-/tryorama-stress-utils-0.0.11.tgz",
+      "integrity": "sha512-+qelFGEheEN8nPTcBpVBjOz56SZrmwLbwGwV6SHPwckxYMFkwe1/Kh89957lLRpzutr2PFR+DxCshJZiVJFD1w==",
+      "dev": true,
+      "requires": {
+        "@holochain/tryorama": "^0.3.0-rc.3",
+        "lodash": "^4.17.15",
+        "moniker": "^0.1.2",
+        "ramda": "^0.26.1",
+        "winston": "^3.2.1"
+      }
+    },
     "@iarna/toml": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/@iarna/toml/-/toml-2.2.5.tgz",
@@ -922,6 +935,12 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "moniker": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/moniker/-/moniker-0.1.2.tgz",
+      "integrity": "sha1-hy37pXXc6o+gSlE1sT1fJL7MyX4=",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/tests/package.json
+++ b/tests/package.json
@@ -4,7 +4,10 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "CARGO_TARGET_DIR=../target cargo build --release --target wasm32-unknown-unknown && dna-util -c ../elemental-chat.dna.workdir && TRYORAMA_LOG_LEVEL=info RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts"
+    "test": "npm run test:setup && npm run test:standard",
+    "test:standard": "TRYORAMA_LOG_LEVEL=info RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/index.ts",
+    "test:setup": "CARGO_TARGET_DIR=../target cargo build --release --target wasm32-unknown-unknown && dna-util -c ../elemental-chat.dna.workdir",
+    "test:behavior": "TRYORAMA_LOG_LEVEL=info RUST_BACKTRACE=1 TRYORAMA_HOLOCHAIN_PATH=\"holochain\" ts-node src/behaviors/index.ts"
   },
   "author": "",
   "license": "ISC",
@@ -17,6 +20,7 @@
   },
   "devDependencies": {
     "@holochain/tryorama": "git://github.com/holochain/tryorama.git#rsm",
+    "@holochain/tryorama-stress-utils": "0.0.11",
     "@types/lodash": "^4.14.158",
     "@types/node": "^14.0.14"
   }

--- a/tests/src/behaviors/config.ts
+++ b/tests/src/behaviors/config.ts
@@ -1,0 +1,20 @@
+const path = require('path')
+const { Config } = require('@holochain/tryorama')
+import { configBatchSimple } from '@holochain/tryorama-stress-utils'
+
+const dnaPath = path.join(__dirname, '../../../elemental-chat.dna.gz')
+console.log(`PAHT: ${dnaPath}`)
+const dnaUri = 'https://github.com/holochain/elemental-chat/fixme.gz'
+
+const commonConfig = {
+    logger: {
+        type: 'info'
+    }
+}
+
+export const batcher = (isRemote, numConductors, instancesPerConductor) => configBatchSimple(
+    numConductors,
+    instancesPerConductor,
+    Config.dna(isRemote ? dnaUri : dnaPath, 'app'),
+    commonConfig
+)

--- a/tests/src/behaviors/index.ts
+++ b/tests/src/behaviors/index.ts
@@ -1,0 +1,26 @@
+import { Orchestrator, tapeExecutor, groupPlayersByMachine, compose } from '@holochain/tryorama'
+import { defaultConfig, behaviorRunner } from './tx-per-minute'  // import config and runner here
+
+const runName = process.argv[2] || ""+Date.now()  // default exam name is just a timestamp
+const config = process.argv[3] ? require(process.argv[3]) : defaultConfig  // use imported config or one passed as a test arg
+
+console.log(`Running behavior test id=${runName} with:\n`, config)
+
+// Below this line should not need changes
+
+config.numConductors = config.nodes * config.conductors
+config.isRemote = Boolean(config.endpoints)
+
+const middleware = /*config.endpoints
+  ? compose(tapeExecutor(require('tape')), groupPlayersByMachine(config.endpoints, config.conductors))
+  :*/ undefined
+
+const orchestrator = new Orchestrator({middleware})
+
+orchestrator.registerScenario('Measuring messages per-minute before slowdown', async (s, t) => {
+    const successRate = await behaviorRunner(s, t, config)  // run runner :-)
+
+    console.log(`successRate: ${successRate}%`)
+})
+
+orchestrator.run()

--- a/tests/src/behaviors/index.ts
+++ b/tests/src/behaviors/index.ts
@@ -1,5 +1,5 @@
 import { Orchestrator, tapeExecutor, groupPlayersByMachine, compose } from '@holochain/tryorama'
-import { defaultConfig, behaviorRunner } from './tx-per-minute'  // import config and runner here
+import { defaultConfig, behaviorRunner } from './tx-per-second'  // import config and runner here
 
 const runName = process.argv[2] || ""+Date.now()  // default exam name is just a timestamp
 const config = process.argv[3] ? require(process.argv[3]) : defaultConfig  // use imported config or one passed as a test arg
@@ -17,10 +17,18 @@ const middleware = /*config.endpoints
 
 const orchestrator = new Orchestrator({middleware})
 
-orchestrator.registerScenario('Measuring messages per-minute before slowdown', async (s, t) => {
-    const successRate = await behaviorRunner(s, t, config)  // run runner :-)
+orchestrator.registerScenario('Measuring messages per-second', async (s, t) => {
 
-    console.log(`successRate: ${successRate}%`)
+    var txCount = 1
+    var actual
+    const period = 10*1000
+    do {
+        txCount *= 2
+        t.comment(`trial with ${txCount} tx per ${period}ms`)
+        actual = await behaviorRunner(s, t, config, period, txCount)  // run runner :-)
+    } while (txCount == actual)
+
+    t.comment(`message per second: ${(actual/period*1000).toFixed(1)} (sent over ${period/1000}s)`)
 })
 
 orchestrator.run()

--- a/tests/src/behaviors/tx-per-minute.ts
+++ b/tests/src/behaviors/tx-per-minute.ts
@@ -56,6 +56,8 @@ export const behaviorRunner = async (s, t, config) => {
         msgs[i] = await sendingConductor.call(sendingCellNick, 'chat', 'create_message', msg)
     }
 
+    console.log(`Getting messages (should be ${messages})`)
+
     const messagesReceived = await sendingConductor.call(receivingCellNick, 'chat', 'list_messages', { channel, date: today() })
 
     console.log(messagesReceived.messages.length)

--- a/tests/src/behaviors/tx-per-minute.ts
+++ b/tests/src/behaviors/tx-per-minute.ts
@@ -1,26 +1,74 @@
-import { Config } from '@holochain/tryorama'
+import { Player } from '@holochain/tryorama'
 import * as _ from 'lodash'
 import { v4 as uuidv4 } from "uuid";
+import { batcher as batchOfConfigs } from './config'
 
 const delay = ms => new Promise(r => setTimeout(r, ms))
 
-// Configure a conductor with two identical DNAs,
-// differentiated by UUID, nicknamed "alice" and "bobbo"
-const config = Config.gen({
-  alice: Config.dna("../elemental-chat.dna.gz", null),
-  bobbo: Config.dna("../elemental-chat.dna.gz", null),
-})
+type Players = Array<Player>
 
+export const defaultConfig = {
+    nodes: 1, // Number of machines
+    conductors: 1, // Conductors per machine
+    instances: 2, // Instances per conductor
+    endpoints: null, // Array of endpoints for Trycp
+}
+
+function prettyCellID(id) {
+    return JSON.stringify(id[1].hash)
+}
+
+export const behaviorRunner = async (s, t, config) => {
+    t.comment(`Preparing playground: initializing conductors and spawning`)
+    const conductorConfigsArray = await batchOfConfigs(config.isRemote, config.conductors, config.instances)
+    const allPlayers = await s.players(conductorConfigsArray, true)
+    let spawnedAgents = 0
+    let cellChannels = {}
+    for (const i in allPlayers) {
+        console.log(`Spawned conductor ${i} with cells:`)
+        for (const j in allPlayers[i]._cellIds) {
+            const conductor = allPlayers[i]
+            console.log(`   ${prettyCellID(conductor._cellIds[j])}`)
+            spawnedAgents++
+            const channel_uuid = uuidv4();
+            const channel = await conductor.call(j, 'chat', 'create_channel', { name: `${i}:${j}'s Test Channel`, channel: { category: "General", uuid: channel_uuid } });
+            console.log(channel);
+            cellChannels[`${i}:${j}`]= channel_uuid
+        }
+    }
+    const sendingConductor = allPlayers["0"]
+    const sendingCellNick = "0"
+    const senderId= "0:0"
+    const channel= { category: 'General', uuid: cellChannels[senderId] }
+    const receivingCellNick = "1"
+
+    var msgs: any[] = [];
+    const messages = 200
+    for (let i =0; i < messages; i++) {
+        const msg = {
+            last_seen: { First: null },
+            channel,
+            message: {
+                uuid: uuidv4(),
+                content: `message ${i}`,
+            }
+        }
+        msgs[i] = await sendingConductor.call(sendingCellNick, 'chat', 'create_message', msg)
+    }
+
+    const messagesReceived = await sendingConductor.call(receivingCellNick, 'chat', 'list_messages', { channel, date: today() })
+
+    console.log(messagesReceived.messages.length)
+
+    return spawnedAgents
+}
+/*
 module.exports = (orchestrator) => {
-  // This is placeholder for signals test; awaiting implementation of signals testing in tryorama.
-  // Issue: https://github.com/holochain/tryorama/issues/40
-  orchestrator.registerScenario.skip('emit signals', async (s, t) => {})
-
-  orchestrator.registerScenario('chat away', async (s, t) => {
+  orchestrator.registerScenario('fish', async (s, t) => {
     // spawn the conductor process
     const { conductor } = await s.players({ conductor: config })
     await conductor.spawn()
-
+return
     // Create a channel
     const channel_uuid = uuidv4();
     const channel = await conductor.call('alice', 'chat', 'create_channel', { name: "Test Channel", channel: { category: "General", uuid: channel_uuid } });
@@ -44,7 +92,7 @@ module.exports = (orchestrator) => {
     console.log(recvs[0]);
     t.deepEqual(sends[0].message, recvs[0].message);
 
-    // Alice sends another message
+    // Alice sends another messag
     sends.push({
       last_seen: { Message: recvs[0].entryHash },
       channel: channel.channel,
@@ -106,7 +154,7 @@ module.exports = (orchestrator) => {
     t.deepEqual([sends[0].message, sends[1].message, sends[2].message, sends[3].message], _.map(msgs[3].messages, just_msg));
   })
 }
-
+*/
 // Get a basic date object for right now
 function today() {
   var today = new Date();


### PR DESCRIPTION
This PR implements a behavior test that's meant to show how many transactions per-second can be send and received and integrated by another cell when the two cells are on the same conductor.

To run the test follow the instructions for the main test in the README, but from the tests directory type:

```
npm run test:behavior
```