### PR TITLE
add test for nodes coming and going

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Twitter Follow](https://img.shields.io/twitter/follow/holochain.svg?style=social&label=Follow)](https://twitter.com/holochain)
 License: [![License: CAL 1.0](https://img.shields.io/badge/License-CAL%201.0-blue.svg)](https://github.com/holochain/cryptographic-autonomy-license)
 
-The most basic of all possible chat apps.
+A fairly basic chat app.  Includes channels, and exercises various holochain features including signals.
 
 ## Running the Tests
 

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -71,8 +71,8 @@
       }
     },
     "@holochain/tryorama": {
-      "version": "github:holochain/tryorama#07db116669d3aa91623ebba5c260a6bd362ec015",
-      "from": "github:holochain/tryorama#07db116669d3aa91623ebba5c260a6bd362ec015",
+      "version": "github:holochain/tryorama#357aaa2d9b4ec54eefbb55f9692ef8c745caf391",
+      "from": "github:holochain/tryorama#357aaa2d9b4ec54eefbb55f9692ef8c745caf391",
       "dev": true,
       "requires": {
         "@holochain/conductor-api": "0.0.1-dev.14",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -71,8 +71,8 @@
       }
     },
     "@holochain/tryorama": {
-      "version": "github:holochain/tryorama#357aaa2d9b4ec54eefbb55f9692ef8c745caf391",
-      "from": "github:holochain/tryorama#357aaa2d9b4ec54eefbb55f9692ef8c745caf391",
+      "version": "github:holochain/tryorama#dee744ae43cd4242b90d55b4f6884f1b84f2aa0e",
+      "from": "github:holochain/tryorama#dee744ae43cd4242b90d55b4f6884f1b84f2aa0e",
       "dev": true,
       "requires": {
         "@holochain/conductor-api": "0.0.1-dev.14",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -36,9 +36,9 @@
       }
     },
     "@holochain/conductor-api": {
-      "version": "0.0.1-dev.12",
-      "resolved": "https://registry.npmjs.org/@holochain/conductor-api/-/conductor-api-0.0.1-dev.12.tgz",
-      "integrity": "sha512-vr06vEFnoYvoJ9zgNaANU/DE04633OK3cXWAdzOGfpZMoeIXXniY/bJx9kgXXJiA+LW5hSCAFDJEBaOV59j2eg==",
+      "version": "0.0.1-dev.14",
+      "resolved": "https://registry.npmjs.org/@holochain/conductor-api/-/conductor-api-0.0.1-dev.14.tgz",
+      "integrity": "sha512-Y10clXo6T6ln5QcHSznQZgzj0Fph000d916RQJKs4qRbD+kU55dYaqoS4AZwAmYoQskeR6i7eF7XPgUD7QYv9A==",
       "dev": true,
       "requires": {
         "@msgpack/msgpack": "^2.1.0",
@@ -71,11 +71,11 @@
       }
     },
     "@holochain/tryorama": {
-      "version": "0.4.0-dev.1",
-      "resolved": "git://github.com/holochain/tryorama.git#9b832887aaa21626ae7ae2461e607d811ba6e79b",
+      "version": "github:holochain/tryorama#07db116669d3aa91623ebba5c260a6bd362ec015",
+      "from": "github:holochain/tryorama#07db116669d3aa91623ebba5c260a6bd362ec015",
       "dev": true,
       "requires": {
-        "@holochain/conductor-api": "0.0.1-dev.12",
+        "@holochain/conductor-api": "0.0.1-dev.14",
         "@holochain/hachiko": "^0.5.2",
         "@iarna/toml": "^2.2.5",
         "async-mutex": "^0.1.4",
@@ -1026,9 +1026,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.18.tgz",
-      "integrity": "sha512-rndlDjbbHbcV3xi+R2fpJ+PbGMdfBxz5v1fATIQFq0DP64FsicQdwnKLy47K4kZHdRpmQXtz24eGsxQqamzYTA==",
+      "version": "3.1.20",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
+      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
       "dev": true
     },
     "next-tick": {
@@ -1587,9 +1587,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-      "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
+      "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
       "dev": true
     },
     "yaml": {

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -71,8 +71,9 @@
       }
     },
     "@holochain/tryorama": {
-      "version": "github:holochain/tryorama#dee744ae43cd4242b90d55b4f6884f1b84f2aa0e",
-      "from": "github:holochain/tryorama#dee744ae43cd4242b90d55b4f6884f1b84f2aa0e",
+      "version": "0.4.0-dev.2",
+      "resolved": "https://registry.npmjs.org/@holochain/tryorama/-/tryorama-0.4.0-dev.2.tgz",
+      "integrity": "sha512-LssGnRae7PAOqv/af5Eel/kl0sx41UttfufYe2sV8woTNmUAl5JhMTXXZBFuZdQx4I2z96BpcFhVQd3p4A+z0Q==",
       "dev": true,
       "requires": {
         "@holochain/conductor-api": "0.0.1-dev.14",

--- a/tests/package.json
+++ b/tests/package.json
@@ -19,7 +19,7 @@
     "uuidv4": "^6.2.3"
   },
   "devDependencies": {
-    "@holochain/tryorama": "^0.4.0-dev.1",
+    "@holochain/tryorama": "holochain/tryorama#07db116669d3aa91623ebba5c260a6bd362ec015",
     "@holochain/tryorama-stress-utils": "0.0.11",
     "@types/lodash": "^4.14.158",
     "@types/node": "^14.0.14"

--- a/tests/package.json
+++ b/tests/package.json
@@ -19,7 +19,7 @@
     "uuidv4": "^6.2.3"
   },
   "devDependencies": {
-    "@holochain/tryorama": "holochain/tryorama#357aaa2d9b4ec54eefbb55f9692ef8c745caf391",
+    "@holochain/tryorama": "holochain/tryorama#dee744ae43cd4242b90d55b4f6884f1b84f2aa0e",
     "@holochain/tryorama-stress-utils": "0.0.11",
     "@types/lodash": "^4.14.158",
     "@types/node": "^14.0.14"

--- a/tests/package.json
+++ b/tests/package.json
@@ -19,7 +19,7 @@
     "uuidv4": "^6.2.3"
   },
   "devDependencies": {
-    "@holochain/tryorama": "holochain/tryorama#dee744ae43cd4242b90d55b4f6884f1b84f2aa0e",
+    "@holochain/tryorama": "0.4.0-dev.2",
     "@holochain/tryorama-stress-utils": "0.0.11",
     "@types/lodash": "^4.14.158",
     "@types/node": "^14.0.14"

--- a/tests/package.json
+++ b/tests/package.json
@@ -19,7 +19,7 @@
     "uuidv4": "^6.2.3"
   },
   "devDependencies": {
-    "@holochain/tryorama": "holochain/tryorama#07db116669d3aa91623ebba5c260a6bd362ec015",
+    "@holochain/tryorama": "holochain/tryorama#357aaa2d9b4ec54eefbb55f9692ef8c745caf391",
     "@holochain/tryorama-stress-utils": "0.0.11",
     "@types/lodash": "^4.14.158",
     "@types/node": "^14.0.14"

--- a/tests/src/elemental-chat.ts
+++ b/tests/src/elemental-chat.ts
@@ -87,13 +87,13 @@ module.exports = (orchestrator) => {
     t.deepEqual(sends[0].message, recvs[0].message);
 
     // list messages should return messages from the correct chunk
-    let msgs = await alice_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} })
+    let msgs = await alice_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} })
     t.deepEqual(msgs.messages[0].message, sends[0].message)
-    msgs = await alice_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:1, end: 1} })
+    msgs = await alice_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:1, end: 1} })
     t.equal(msgs.messages.length, 0)
-    msgs = await alice_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:32, end: 32} })
+    msgs = await alice_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:32, end: 32} })
     t.deepEqual(msgs.messages[0].message, sends[1].message)
-    msgs = await alice_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 32} })
+    msgs = await alice_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 32} })
     t.deepEqual(msgs.messages.length, 2)
 
     // list channels should have the latest chunk
@@ -162,12 +162,12 @@ module.exports = (orchestrator) => {
 
     // Alice lists the messages
     var msgs: any[] = [];
-    msgs.push(await alice_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} }));
+    msgs.push(await alice_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} }));
     console.log(_.map(msgs[0].messages, just_msg));
     t.deepEqual([sends[0].message, sends[1].message], _.map(msgs[0].messages, just_msg));
     // Bobbo lists the messages
     await delay(2000) // TODO add consistency instead
-    msgs.push(await bobbo_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} }));
+    msgs.push(await bobbo_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} }));
     console.log('bobbo.list_messages: '+_.map(msgs[1].messages, just_msg));
     t.deepEqual([sends[0].message, sends[1].message], _.map(msgs[1].messages, just_msg));
 
@@ -198,11 +198,11 @@ module.exports = (orchestrator) => {
     t.deepEqual(sends[3].message, recvs[3].message);
     await delay(4000)
     // Alice lists the messages
-    msgs.push(await alice_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} }));
+    msgs.push(await alice_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} }));
     console.log(_.map(msgs[2].messages, just_msg));
     t.deepEqual([sends[0].message, sends[1].message, sends[2].message, sends[3].message], _.map(msgs[2].messages, just_msg));
     // Bobbo lists the messages
-    msgs.push(await bobbo_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} }));
+    msgs.push(await bobbo_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} }));
     console.log(_.map(msgs[3].messages, just_msg));
     t.deepEqual([sends[0].message, sends[1].message, sends[2].message, sends[3].message], _.map(msgs[3].messages, just_msg));
   })
@@ -250,7 +250,7 @@ const doTransientNodes = async (s, t, local) => {
 
   var retries = 10
   while (true) {
-    const r2 = await bob_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} })
+    const r2 = await bob_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} })
     t.ok(r2)
     if (r2.messages.length == 1) {
       break;
@@ -277,7 +277,7 @@ const doTransientNodes = async (s, t, local) => {
 
   retries = 10
   while (true) {
-    const r2 = await carol_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} })
+    const r2 = await carol_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} })
     console.log("Carol list message:", r2)
     t.ok(r2)
     if (r2.messages.length == 1) {
@@ -303,7 +303,7 @@ const doTransientNodes = async (s, t, local) => {
 
     retries = 10
     while (true) {
-      const r2 = await carol_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} })
+      const r2 = await carol_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} })
       console.log("Carol list message:", r2)
       t.ok(r2)
       if (r2.messages.length == 1) {

--- a/tests/src/elemental-chat.ts
+++ b/tests/src/elemental-chat.ts
@@ -210,7 +210,7 @@ module.exports = (orchestrator) => {
     t.deepEqual([sends[0].message, sends[1].message, sends[2].message, sends[3].message], _.map(msgs[3].messages, just_msg));
   })
 
-  orchestrator.registerScenario('transient nodes-local', async (s, t) => {
+  orchestrator.registerScenario.only('transient nodes-local', async (s, t) => {
     await doTransientNodes(s, t, true)
   })
 

--- a/tests/src/elemental-chat.ts
+++ b/tests/src/elemental-chat.ts
@@ -210,11 +210,11 @@ module.exports = (orchestrator) => {
     t.deepEqual([sends[0].message, sends[1].message, sends[2].message, sends[3].message], _.map(msgs[3].messages, just_msg));
   })
 
-  orchestrator.registerScenario.only('transient nodes-local', async (s, t) => {
+  orchestrator.registerScenario('transient nodes-local', async (s, t) => {
     await doTransientNodes(s, t, true)
   })
 
-  orchestrator.registerScenario('transient nodes-proxied', async (s, t) => {
+  orchestrator.registerScenario.only('transient nodes-proxied', async (s, t) => {
     await doTransientNodes(s, t, false)
   })
 }
@@ -278,7 +278,9 @@ const doTransientNodes = async (s, t, local) => {
   console.log("******************************************************************")
   console.log("checking to see if bob can see the message")
   await gotChannelsAndMessages(t, "bob", bob_chat, channel.channel, RETRY_COUNT, RETRY_DELAY)
-
+  console.log("waiting for bob to integrate the message not just see it via get")
+  await delay(10000)
+  console.log("shutting down alice")
   await alice.shutdown()
   await carol.startup()
   const [[carol_chat_happ]] = await carol.installAgentsHapps(installation1agent)

--- a/tests/src/elemental-chat.ts
+++ b/tests/src/elemental-chat.ts
@@ -22,7 +22,7 @@ const network = {
   }],
 }
 
-const networkedConductorConfig = Config.gen({network})
+const networkedConductorConfig = Config.gen(/*{network}*/)
 
 
 // Construct proper paths for your DNAs
@@ -217,6 +217,7 @@ module.exports = (orchestrator) => {
     const [alice_chat] = alice_chat_happ.cells
     const [bob_chat] = bob_chat_happ.cells
 
+    await s.shareAllNodes([alice,bob]);
 
     // Create a channel
     const channel_uuid = uuidv4();
@@ -257,8 +258,9 @@ module.exports = (orchestrator) => {
     const [[carol_chat_happ]] = await carol.installAgentsHapps(installation1agent)
     const [carol_chat] = carol_chat_happ.cells
 
+    await s.shareAllNodes([carol, bob]);
 
-    retries = 5
+    retries = 10
     while (true) {
       const r2 = await carol_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} })
       console.log("Carol list message:", r2)
@@ -270,7 +272,7 @@ module.exports = (orchestrator) => {
         retries -= 1;
         if (retries == 0) {
           console.log("bailing after 10 retries")
-         // t.equal(r2.messages.length,1)
+          t.equal(r2.messages.length,1)
           break;
         }
       }

--- a/tests/src/elemental-chat.ts
+++ b/tests/src/elemental-chat.ts
@@ -211,7 +211,7 @@ module.exports = (orchestrator) => {
     await doTransientNodes(s, t, true)
   })
 
-  orchestrator.registerScenario('transient nodes-proxied', async (s, t) => {
+  orchestrator.registerScenario.only('transient nodes-proxied', async (s, t) => {
     await doTransientNodes(s, t, false)
   })
 }

--- a/tests/src/elemental-chat.ts
+++ b/tests/src/elemental-chat.ts
@@ -22,7 +22,7 @@ const network = {
   }],
 }
 
-const networkedConductorConfig = Config.gen(/*{network}*/)
+const networkedConductorConfig = Config.gen({network})
 
 
 // Construct proper paths for your DNAs
@@ -103,7 +103,7 @@ module.exports = (orchestrator) => {
 
   })
 
-  orchestrator.registerScenario('chat away', async (s, t) => {
+  orchestrator.registerScenario.skip('chat away', async (s, t) => {
     // Declare two players using the previously specified config, nicknaming them "alice" and "bob"
     // note that the first argument to players is just an array conductor configs that that will
     // be used to spin up the conductor processes which are returned in a matching array.
@@ -156,6 +156,7 @@ module.exports = (orchestrator) => {
     recvs.push(await alice_chat.call('chat', 'create_message', sends[1]));
     console.log(recvs[1]);
     t.deepEqual(sends[1].message, recvs[1].message);
+    await delay(2000) // TODO add consistency instead
 
     const channel_list = await alice_chat.call('chat', 'list_channels', { category: "General" });
     console.log(channel_list);
@@ -166,7 +167,7 @@ module.exports = (orchestrator) => {
     console.log(_.map(msgs[0].messages, just_msg));
     t.deepEqual([sends[0].message, sends[1].message], _.map(msgs[0].messages, just_msg));
     // Bobbo lists the messages
-    await delay( 1000 )
+    await delay(2000) // TODO add consistency instead
     msgs.push(await bobbo_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} }));
     console.log('bobbo.list_messages: '+_.map(msgs[1].messages, just_msg));
     t.deepEqual([sends[0].message, sends[1].message], _.map(msgs[1].messages, just_msg));
@@ -196,7 +197,7 @@ module.exports = (orchestrator) => {
     recvs.push(await alice_chat.call('chat', 'create_message', sends[3]));
     console.log(recvs[3]);
     t.deepEqual(sends[3].message, recvs[3].message);
-
+    await delay(2000)
     // Alice lists the messages
     msgs.push(await alice_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} }));
     console.log(_.map(msgs[2].messages, just_msg));
@@ -207,78 +208,93 @@ module.exports = (orchestrator) => {
     t.deepEqual([sends[0].message, sends[1].message, sends[2].message, sends[3].message], _.map(msgs[3].messages, just_msg));
   })
 
-  orchestrator.registerScenario.only('transient nodes', async (s, t) => {
-    const [alice, bob, carol] = await s.players([networkedConductorConfig, networkedConductorConfig, networkedConductorConfig], false)
-    await alice.startup()
-    await bob.startup()
+  orchestrator.registerScenario('transient nodes-local', async (s, t) => {
+    await doTransientNodes(s, t, true)
+  })
 
-    const [[alice_chat_happ]] = await alice.installAgentsHapps(installation1agent)
-    const [[bob_chat_happ]] = await bob.installAgentsHapps(installation1agent)
-    const [alice_chat] = alice_chat_happ.cells
-    const [bob_chat] = bob_chat_happ.cells
+  orchestrator.registerScenario('transient nodes-proxied', async (s, t) => {
+    await doTransientNodes(s, t, false)
+  })
+}
 
-    await s.shareAllNodes([alice,bob]);
+const doTransientNodes = async (s, t, local) => {
+  const config = local ? conductorConfig : networkedConductorConfig;
 
-    // Create a channel
-    const channel_uuid = uuidv4();
-    const channel = await alice_chat.call('chat', 'create_channel', { name: "Test Channel", channel: { category: "General", uuid: channel_uuid } });
+  const [alice, bob, carol] = await s.players([config, config, config], false)
+  await alice.startup()
+  await bob.startup()
 
-    const msg1 = {
-      last_seen: { First: null },
-      channel: channel.channel,
-      chunk: 0,
-      message: {
-        uuid: uuidv4(),
-        content: "Hello from alice :)",
-      }
+  const [[alice_chat_happ]] = await alice.installAgentsHapps(installation1agent)
+  const [[bob_chat_happ]] = await bob.installAgentsHapps(installation1agent)
+  const [alice_chat] = alice_chat_happ.cells
+  const [bob_chat] = bob_chat_happ.cells
+
+  if (local) {
+    await s.shareAllNodes([alice, bob]);
+  }
+
+  // Create a channel
+  const channel_uuid = uuidv4();
+  const channel = await alice_chat.call('chat', 'create_channel', { name: "Test Channel", channel: { category: "General", uuid: channel_uuid } });
+
+  const msg1 = {
+    last_seen: { First: null },
+    channel: channel.channel,
+    chunk: 0,
+    message: {
+      uuid: uuidv4(),
+      content: "Hello from alice :)",
     }
-    const r1 = await alice_chat.call('chat', 'create_message', msg1);
-    t.deepEqual(r1.message, msg1.message);
+  }
+  const r1 = await alice_chat.call('chat', 'create_message', msg1);
+  t.deepEqual(r1.message, msg1.message);
 
-    var retries = 10
-    while (true) {
-      const r2 = await bob_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} })
-      t.ok(r2)
-      if (r2.messages.length == 1) {
+  var retries = 10
+  while (true) {
+    const r2 = await bob_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} })
+    t.ok(r2)
+    if (r2.messages.length == 1) {
+      break;
+    }
+    else {
+      retries -= 1;
+      if (retries == 0) {
+        t.equal(r2.messages.length,1)
         break;
       }
-      else {
-        retries -= 1;
-        if (retries == 0) {
-          t.equal(r2.messages.length,1)
-          break;
-        }
-      }
-      console.log(`retry ${retries}`);
-      await delay( 1000 )
     }
+    console.log(`retry ${retries}`);
+    await delay( 1000 )
+  }
 
-    await alice.shutdown()
-    await carol.startup()
-    const [[carol_chat_happ]] = await carol.installAgentsHapps(installation1agent)
-    const [carol_chat] = carol_chat_happ.cells
+  await alice.shutdown()
+  await carol.startup()
+  const [[carol_chat_happ]] = await carol.installAgentsHapps(installation1agent)
+  const [carol_chat] = carol_chat_happ.cells
 
+  if (local) {
     await s.shareAllNodes([carol, bob]);
+  }
 
-    retries = 10
-    while (true) {
-      const r2 = await carol_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} })
-      console.log("Carol list message:", r2)
-      t.ok(r2)
-      if (r2.messages.length == 1) {
+  retries = 10
+  while (true) {
+    const r2 = await carol_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} })
+    console.log("Carol list message:", r2)
+    t.ok(r2)
+    if (r2.messages.length == 1) {
+      break;
+    }
+    else {
+      retries -= 1;
+      if (retries == 0) {
+        console.log("bailing after 10 retries")
+        t.equal(r2.messages.length,1)
         break;
       }
-      else {
-        retries -= 1;
-        if (retries == 0) {
-          console.log("bailing after 10 retries")
-          t.equal(r2.messages.length,1)
-          break;
-        }
-      }
-      console.log(`retry ${retries}`);
-      await delay( 1000 )
     }
+    console.log(`retry ${retries}`);
+    await delay( 1000 )
+  }
 
 
     // This above loop SHOULD work because carol should get the message via bob, but it doesn't
@@ -317,7 +333,4 @@ module.exports = (orchestrator) => {
     const carol_blog_happ = await carol.installHapp([dnaBlog])
     // or a happ with a previously generated key
 */
-  })
-
-
 }

--- a/tests/src/elemental-chat.ts
+++ b/tests/src/elemental-chat.ts
@@ -248,8 +248,12 @@ const doTransientNodes = async (s, t, local) => {
   const r1 = await alice_chat.call('chat', 'create_message', msg1);
   t.deepEqual(r1.message, msg1.message);
 
+
+  console.log("checking to see if bob can see the message")
   var retries = 10
   while (true) {
+    const channel_list = await bob_chat.call('chat', 'list_channels', { category: "General" });
+    console.log("BOB CHANNELS", channel_list.channels);
     const r2 = await bob_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} })
     t.ok(r2)
     if (r2.messages.length == 1) {
@@ -275,8 +279,12 @@ const doTransientNodes = async (s, t, local) => {
     await s.shareAllNodes([carol, bob]);
   }
 
-  retries = 10
+  console.log("******************************************************************")
+  console.log("checking to see if carol can see the message via bob")
+  retries = 20
   while (true) {
+    const channel_list = await carol_chat.call('chat', 'list_channels', { category: "General" });
+    console.log("CAROL CHANNELS", channel_list.channels);
     const r2 = await carol_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} })
     console.log("Carol list message:", r2)
     t.ok(r2)
@@ -301,8 +309,12 @@ const doTransientNodes = async (s, t, local) => {
     // doesn't work!
     await alice.startup()
 
+  console.log("******************************************************************")
+  console.log("checking to see if carol can see the message via alice after back on")
     retries = 10
     while (true) {
+      const channel_list = await carol_chat.call('chat', 'list_channels', { category: "General" });
+      console.log("CAROL CHANNELS", channel_list.channels);
       const r2 = await carol_chat.call('chat', 'list_messages', { channel: channel.channel, active_chatter: false, chunk: {start:0, end: 1} })
       console.log("Carol list message:", r2)
       t.ok(r2)

--- a/tests/src/elemental-chat.ts
+++ b/tests/src/elemental-chat.ts
@@ -103,7 +103,7 @@ module.exports = (orchestrator) => {
 
   })
 
-  orchestrator.registerScenario.skip('chat away', async (s, t) => {
+  orchestrator.registerScenario('chat away', async (s, t) => {
     // Declare two players using the previously specified config, nicknaming them "alice" and "bob"
     // note that the first argument to players is just an array conductor configs that that will
     // be used to spin up the conductor processes which are returned in a matching array.
@@ -156,7 +156,6 @@ module.exports = (orchestrator) => {
     recvs.push(await alice_chat.call('chat', 'create_message', sends[1]));
     console.log(recvs[1]);
     t.deepEqual(sends[1].message, recvs[1].message);
-    await delay(2000) // TODO add consistency instead
 
     const channel_list = await alice_chat.call('chat', 'list_channels', { category: "General" });
     console.log(channel_list);
@@ -197,7 +196,7 @@ module.exports = (orchestrator) => {
     recvs.push(await alice_chat.call('chat', 'create_message', sends[3]));
     console.log(recvs[3]);
     t.deepEqual(sends[3].message, recvs[3].message);
-    await delay(2000)
+    await delay(4000)
     // Alice lists the messages
     msgs.push(await alice_chat.call('chat', 'list_messages', { channel: channel.channel, chunk: {start:0, end: 1} }));
     console.log(_.map(msgs[2].messages, just_msg));

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 
-hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "052a4235f6158802ae27e129d7942a0435583b2a" }
+hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "c301551ba63db604aa2868b6b22a7a6013a16420" }
 # hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
 serde = "=1.0.104"
 chrono = { version = "0.4", features = ['alloc', 'std']}

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elemental-chat"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 authors = [ "michael.dougherty@holo.host", "philip.beadle@holo.host", "david.meister@holo.host, tom.gowan@holo.host" ]
 edition = "2018"
 

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 
-hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "c2e6d71e159de0e549ec08838fc7d1093fcd8964" }
+hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "f99c0e7d17500933f725a31e07513b60cafa6f57" }
 # hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
 serde = "=1.0.104"
 chrono = { version = "0.4", features = ['alloc', 'std']}

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 
-hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "37875db509b27952eba6cc965eeefc92dfd93370" }
+hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "6db4d3e84a565d75b3576a2d1490ca7c84990543" }
 # hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
 serde = "=1.0.104"
 chrono = { version = "0.4", features = ['alloc', 'std']}

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 
-hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "6db4d3e84a565d75b3576a2d1490ca7c84990543" }
+hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "052a4235f6158802ae27e129d7942a0435583b2a" }
 # hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
 serde = "=1.0.104"
 chrono = { version = "0.4", features = ['alloc', 'std']}

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 
-hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "c301551ba63db604aa2868b6b22a7a6013a16420" }
+hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "052a4235f6158802ae27e129d7942a0435583b2a" }
 # hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
 serde = "=1.0.104"
 chrono = { version = "0.4", features = ['alloc', 'std']}

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elemental-chat"
-version = "0.0.1-alpha4"
+version = "0.0.1-alpha7"
 authors = [ "michael.dougherty@holo.host", "philip.beadle@holo.host", "david.meister@holo.host, tom.gowan@holo.host" ]
 edition = "2018"
 
@@ -10,7 +10,7 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 
-hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "f99c0e7d17500933f725a31e07513b60cafa6f57" }
+hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "43b0f45bd2784f8b993085cbae714c8537c2e082" }
 # hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
 serde = "=1.0.104"
 chrono = { version = "0.4", features = ['alloc', 'std']}

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 
-hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "052a4235f6158802ae27e129d7942a0435583b2a" }
+hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "c2e6d71e159de0e549ec08838fc7d1093fcd8964" }
 # hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
 serde = "=1.0.104"
 chrono = { version = "0.4", features = ['alloc', 'std']}

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -9,7 +9,9 @@ name = "chat"
 crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
-hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
+
+hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "37875db509b27952eba6cc965eeefc92dfd93370" }
+# hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
 serde = "=1.0.104"
 chrono = { version = "0.4", features = ['alloc', 'std']}
 derive_more = "0.99.9"

--- a/zomes/chat/src/entries/channel/handlers.rs
+++ b/zomes/chat/src/entries/channel/handlers.rs
@@ -98,7 +98,7 @@ pub(crate) fn list_channels(list_channels_input: ChannelListInput) -> ChatResult
         }
 
         // Get the actual channel info entry
-        if let Some(element) = get(latest_info.target,  GetOptions::default())? {
+        if let Some(element) = get(latest_info.target,  GetOptions::content())? {
             if let Some(info) = element.into_inner().1.to_app_option()? {
                 // Construct the channel data from the channel and info
                 channels.push(ChannelData {

--- a/zomes/chat/src/entries/channel/handlers.rs
+++ b/zomes/chat/src/entries/channel/handlers.rs
@@ -98,7 +98,7 @@ pub(crate) fn list_channels(list_channels_input: ChannelListInput) -> ChatResult
         }
 
         // Get the actual channel info entry
-        if let Some(element) = get(latest_info.target, Default::default())? {
+        if let Some(element) = get(latest_info.target,  GetOptions::content())? {
             if let Some(info) = element.into_inner().1.to_app_option()? {
                 // Construct the channel data from the channel and info
                 channels.push(ChannelData {

--- a/zomes/chat/src/entries/channel/handlers.rs
+++ b/zomes/chat/src/entries/channel/handlers.rs
@@ -98,7 +98,7 @@ pub(crate) fn list_channels(list_channels_input: ChannelListInput) -> ChatResult
         }
 
         // Get the actual channel info entry
-        if let Some(element) = get(latest_info.target,  GetOptions::content())? {
+        if let Some(element) = get(latest_info.target,  GetOptions::default())? {
             if let Some(info) = element.into_inner().1.to_app_option()? {
                 // Construct the channel data from the channel and info
                 channels.push(ChannelData {

--- a/zomes/chat/src/entries/message.rs
+++ b/zomes/chat/src/entries/message.rs
@@ -54,6 +54,7 @@ pub struct SignalMessageData {
 pub struct ListMessagesInput {
     channel: Channel,
     chunk: Chunk,
+    active_chatter: bool,
 }
 #[derive(Serialize, Deserialize, SerializedBytes)]
 pub struct Chunk {

--- a/zomes/chat/src/entries/message/handlers.rs
+++ b/zomes/chat/src/entries/message/handlers.rs
@@ -114,7 +114,7 @@ fn get_messages(links: Vec<Link>) -> ChatResult<Vec<MessageData>> {
         // Get details because we are going to return the original message and
         // allow the UI to follow the CRUD tree to find which message
         // to actually display.
-        let message = match get_details(target, Default::default())? {
+        let message = match get_details(target, GetOptions::content())? {
             Some(Details::Entry(EntryDetails {
                 entry, mut headers, ..
             })) => {

--- a/zomes/chat/src/entries/message/handlers.rs
+++ b/zomes/chat/src/entries/message/handlers.rs
@@ -116,7 +116,7 @@ fn get_messages(links: Vec<Link>) -> ChatResult<Vec<MessageData>> {
         // Get details because we are going to return the original message and
         // allow the UI to follow the CRUD tree to find which message
         // to actually display.
-        let message = match get_details(target, GetOptions::content())? {
+        let message = match get_details(target, GetOptions::default())? {
             Some(Details::Entry(EntryDetails {
                 entry, mut headers, ..
             })) => {

--- a/zomes/chat/src/entries/message/handlers.rs
+++ b/zomes/chat/src/entries/message/handlers.rs
@@ -62,11 +62,13 @@ pub(crate) fn create_message(message_input: MessageInput) -> ChatResult<MessageD
 
 /// List all the messages on this channel
 pub(crate) fn list_messages(list_message_input: ListMessagesInput) -> ChatResult<ListMessages> {
-    let ListMessagesInput { channel, chunk } = list_message_input;
+    let ListMessagesInput { channel, chunk, active_chatter } = list_message_input;
 
     // Check if our agent key is active on this path and
     // add it if it's not
-    add_chatter(channel.chatters_path())?;
+    if active_chatter {
+        add_chatter(channel.chatters_path())?;
+    }
 
     let mut links: Vec<Link> = Vec::new();
     let mut counter = chunk.start;

--- a/zomes/chat/src/entries/message/handlers.rs
+++ b/zomes/chat/src/entries/message/handlers.rs
@@ -116,7 +116,7 @@ fn get_messages(links: Vec<Link>) -> ChatResult<Vec<MessageData>> {
         // Get details because we are going to return the original message and
         // allow the UI to follow the CRUD tree to find which message
         // to actually display.
-        let message = match get_details(target, GetOptions::default())? {
+        let message = match get_details(target, GetOptions::content())? {
             Some(Details::Entry(EntryDetails {
                 entry, mut headers, ..
             })) => {


### PR DESCRIPTION
This pr adds a test to prove out the case where nodes come and go and especially to prove out that they can get data from non-authorities when the authorities have gone off-line.

Includes two versions of the test, one running locally skipping bootstrapping, and another using bootstrap server and proxy server.