### PR TITLE
simplify signalable chatters

### DIFF
--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elemental-chat"
-version = "0.0.1-alpha7"
+version = "0.0.1-alpha8"
 authors = [ "michael.dougherty@holo.host", "philip.beadle@holo.host", "david.meister@holo.host, tom.gowan@holo.host" ]
 edition = "2018"
 
@@ -10,8 +10,7 @@ crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
 
-hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "43b0f45bd2784f8b993085cbae714c8537c2e082" }
-# hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "bc2377395b08c06d54021978df3c365074fc2c10" }
+hdk3 = { git = "https://github.com/holochain/holochain.git", rev = "3a437bab4b09de35c3ef67fc8f6a384a84e471e3" }
 serde = "=1.0.104"
 chrono = { version = "0.4", features = ['alloc', 'std']}
 derive_more = "0.99.9"

--- a/zomes/chat/src/entries/channel.rs
+++ b/zomes/chat/src/entries/channel.rs
@@ -28,6 +28,7 @@ pub struct Channel {
     uuid: String,
 }
 
+/*  using global chatters list for now.
 impl Channel {
     pub fn chatters_path(&self) -> Path {
         let mut components: Vec<Component> = Path::from(self.clone()).into();
@@ -35,6 +36,7 @@ impl Channel {
         components.into()
     }
 }
+ */
 
 /// The message type that goes to the UI
 #[derive(Serialize, Deserialize, SerializedBytes, derive_more::Constructor, Debug, Clone)]

--- a/zomes/chat/src/entries/message.rs
+++ b/zomes/chat/src/entries/message.rs
@@ -62,6 +62,13 @@ pub struct Chunk {
     end: u32,
 }
 
+#[derive(Serialize, Deserialize, SerializedBytes)]
+pub struct SigResults {
+    pub total: usize,
+    pub active: usize,
+    pub sent: usize,
+}
+
 /// The messages returned from list messages
 #[derive(Serialize, Deserialize, SerializedBytes, derive_more::From)]
 pub struct ListMessages {

--- a/zomes/chat/src/entries/message/handlers.rs
+++ b/zomes/chat/src/entries/message/handlers.rs
@@ -62,13 +62,14 @@ pub(crate) fn create_message(message_input: MessageInput) -> ChatResult<MessageD
 
 /// List all the messages on this channel
 pub(crate) fn list_messages(list_message_input: ListMessagesInput) -> ChatResult<ListMessages> {
-    let ListMessagesInput { channel, chunk, active_chatter } = list_message_input;
+    let ListMessagesInput { channel, chunk, active_chatter: _ } = list_message_input;
 
+    // Removing for now and expecting UI to call add_chatter once every 2 hours.
     // Check if our agent key is active on this path and
     // add it if it's not
-    if active_chatter {
-        add_chatter(channel.chatters_path())?;
-    }
+    //if active_chatter {
+    //    add_chatter(/*channel.chatters_path()*/)?;
+    //}
 
     let mut links: Vec<Link> = Vec::new();
     let mut counter = chunk.start;
@@ -148,6 +149,12 @@ fn add_chunk_path(path: Path, chunk: u32) -> ChatResult<Path> {
     Ok(components.into())
 }
 
+fn chatters_path() -> Path {
+    Path::from("chatters")
+}
+
+/*  At some point maybe add back in chatters  on a channel, but for now
+simple list of global chatters.
 pub(crate) fn signal_users_on_channel(signal_message_data: SignalMessageData) -> ChatResult<()> {
     let me = agent_info()?.agent_latest_pubkey;
 
@@ -158,17 +165,30 @@ pub(crate) fn signal_users_on_channel(signal_message_data: SignalMessageData) ->
     let hour_path = add_current_hour_minus_n_path(path, 1)?;
     hour_path.ensure()?;
     signal_hour(hour_path, signal_message_data, me)?;
-    Ok(())
-}
 
-fn signal_hour(
-    hour_path: Path,
+    let path: Path = chatters_path();
+    signal_chatters(path, signal_message_data, me)?;
+
+    Ok(())
+} */
+
+const CHAT_HOURS : i64 = 2;
+
+pub(crate) fn signal_chatters(
     signal_message_data: SignalMessageData,
-    me: AgentPubKey,
 ) -> ChatResult<()> {
-    let chatters = get_links(hour_path.hash()?, None)?.into_inner();
+    let me = agent_info()?.agent_latest_pubkey;
+    let chatters_path: Path = chatters_path();
+    let chatters = get_links(chatters_path.hash()?, None)?.into_inner();
     debug!(format!("num online chatters {}", chatters.len()));
-    for tag in chatters.into_iter().map(|l| l.tag) {
+    let now = to_date(sys_time()?);
+    for link in chatters.into_iter().filter(|l| {
+//        let naive_time : chrono::NaiveDateTime = .into();
+        let link_time = chrono::DateTime::<chrono::Utc>::from(l.timestamp);
+        now.signed_duration_since(link_time).num_hours() > CHAT_HOURS
+    }
+    ) {
+        let tag = link.tag;
         let agent = tag_to_agent(tag)?;
         if agent == me {
             continue;
@@ -186,6 +206,16 @@ fn signal_hour(
     Ok(())
 }
 
+// simplified and expected as a zome call
+pub(crate)  fn refresh_chatter() -> ChatResult<()> {
+    let path: Path = chatters_path();
+    let agent = agent_info()?.agent_latest_pubkey;
+    let agent_tag = agent_to_tag(&agent);
+    create_link(path.hash()?, agent.into(), agent_tag.clone())?;
+    Ok(())
+}
+
+/* old way using hours
 fn add_chatter(path: Path) -> ChatResult<()> {
     let agent = agent_info()?.agent_latest_pubkey;
     let agent_tag = agent_to_tag(&agent);
@@ -206,6 +236,7 @@ fn add_chatter(path: Path) -> ChatResult<()> {
 
     Ok(())
 }
+*/
 
 fn agent_to_tag(agent: &AgentPubKey) -> LinkTag {
     let agent_tag: &[u8] = agent.as_ref();
@@ -216,6 +247,7 @@ fn tag_to_agent(tag: LinkTag) -> ChatResult<AgentPubKey> {
     Ok(AgentPubKey::from_raw_39(tag.0).map_err(|_| ChatError::AgentTag)?)
 }
 
+/*
 fn add_current_hour_path(path: Path) -> ChatResult<Path> {
     add_current_hour_path_inner(path, None)
 }
@@ -253,3 +285,4 @@ fn date_minus_hours(
     let hours = chrono::Duration::hours(hours as i64);
     date - hours
 }
+*/

--- a/zomes/chat/src/lib.rs
+++ b/zomes/chat/src/lib.rs
@@ -72,10 +72,21 @@ fn create_message(message_input: MessageInput) -> ChatResult<MessageData> {
     message::handlers::create_message(message_input)
 }
 
-#[hdk_extern]
+/*#[hdk_extern]
 fn signal_users_on_channel(message_data: SignalMessageData) -> ChatResult<()> {
     message::handlers::signal_users_on_channel(message_data)
+}*/
+
+#[hdk_extern]
+fn signal_chatters(message_data: SignalMessageData) -> ChatResult<()> {
+    message::handlers::signal_chatters(message_data)
 }
+
+#[hdk_extern]
+fn refresh_chatter(_: ()) -> ChatResult<()> {
+    message::handlers::refresh_chatter()
+}
+
 
 #[hdk_extern]
 fn new_message_signal(message_input: SignalMessageData) -> ChatResult<()> {

--- a/zomes/chat/src/lib.rs
+++ b/zomes/chat/src/lib.rs
@@ -4,7 +4,7 @@ use error::ChatResult;
 use hdk3::prelude::Path;
 use hdk3::prelude::*;
 use message::{
-    ListMessages, ListMessagesInput, Message, MessageData, MessageInput, SignalMessageData,
+    ListMessages, ListMessagesInput, Message, MessageData, MessageInput, SignalMessageData, SigResults
 };
 
 mod entries;
@@ -78,7 +78,7 @@ fn signal_users_on_channel(message_data: SignalMessageData) -> ChatResult<()> {
 }*/
 
 #[hdk_extern]
-fn signal_chatters(message_data: SignalMessageData) -> ChatResult<()> {
+fn signal_chatters(message_data: SignalMessageData) -> ChatResult<SigResults> {
     message::handlers::signal_chatters(message_data)
 }
 


### PR DESCRIPTION
Changes the algorithm of how current "chatters" are handled to a simpler version where the UI is expected to call "refresh_chatter" every two hours when it is active.

The zome simply counts active chatters as those who've added a link to a "chatters" anchor within the last 2 hours. 