### PR TITLE
README: Include `holochain -i` in set up instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ A fairly basic chat app.  Includes channels, and exercises various holochain fea
   - Clone this repo: `git clone https://github.com/holochain/elemental-chat && cd ./elemental-chat`
   - Build the wasm: `CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown`
   - Assemble the DNA: `dna-util -c elemental-chat.dna.workdir`
+- Set up Holochain environment:
+  - Run `holochain -i` and say yes at the prompts.
+  - Once it's done setting up, kill it with <kbd>Ctrl</kbd>+<kbd>C</kbd>
 
 ## Running
 


### PR DESCRIPTION
Before running `holochain -i`, `cd tests; npm test` gave

```
16:15:08 [tryorama] info: Spawning lair for test with keystore at:  /run/user/1000/tryorama/kOl6lH/keystore
Error: spawn lair-keystore ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:269:19)
    at onErrorNT (node:internal/child_process:465:16)
    at processTicksAndRejections (node:internal/process/task_queues:80:21)
```

After running `holochain -i`, tests pass.