### PR TITLE
Bypass checking membrane proof signature for now

### DIFF
--- a/release-builds.sh
+++ b/release-builds.sh
@@ -3,6 +3,8 @@ build () {
     sed -i "s/uuid: .*/uuid: \"$2\"/" happ.yaml
     hc app pack . -o elemental-chat.$1.$2.happ
 }
-build 0_1_0_alpha1 0002
-build 0_1_0_alpha1 0001
-build 0_1_0_alpha1 develop
+# get the version from the chat zome Cargo.toml
+VERSION=`grep -Po '^version = "\K([^"]+)' zomes/chat/Cargo.toml | sed -e "s/[.-]/_/g"`
+build $VERSION 0002
+build $VERSION 0001
+build $VERSION develop

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elemental-chat"
-version = "0.2.0-alpha1"
+version = "0.2.0-alpha3"
 authors = [ "michael.dougherty@holo.host", "philip.beadle@holo.host", "david.meister@holo.host, tom.gowan@holo.host" ]
 edition = "2018"
 

--- a/zomes/chat/src/validation.rs
+++ b/zomes/chat/src/validation.rs
@@ -13,7 +13,6 @@ struct JoiningCodePayload {
 pub(crate) fn joining_code(element: Element) -> ExternResult<ValidateCallbackResult> {
     // This is a hard coded holo agent public key
     let holo_agent = AgentPubKey::try_from("uhCAkfzycXcycd-OS6HQHvhTgeDVjlkFdE2-XHz-f_AC_5xelQX1N").unwrap();
-
     match element.signed_header().header() {
         Header::AgentValidationPkg(pkg) => {
             match &pkg.membrane_proof {
@@ -28,17 +27,25 @@ pub(crate) fn joining_code(element: Element) -> ExternResult<ValidateCallbackRes
                         return Ok(ValidateCallbackResult::Invalid(format!("Joining code invalid: unexpected author ({:?})", author)))
                     }
 
-                    let signature = mem_proof.signature().clone();
-                    if let ElementEntry::Present(entry) = mem_proof.entry() {
-                        let jcp = JoiningCodePayload::try_from(entry.clone())?;
+                    let _signature = mem_proof.signature().clone();
+                    if let ElementEntry::Present(_entry) = mem_proof.entry() {
+                        if *mem_proof.header().author() != holo_agent {
+                            debug!("Joining code not created by holo_agent");
+                            return Ok(ValidateCallbackResult::Invalid("Joining code invalid: incorrect holo agent".to_string()))
+                        }
 
+                        debug!("Joining code validated without checking signature");
+                        return Ok(ValidateCallbackResult::Valid)
+/*
+                        let jcp = JoiningCodePayload::try_from(entry.clone())?;
+                        let jcp = element.into_inner().1;
                         if verify_signature(holo_agent.clone(), signature, SerializedBytes::try_from(jcp.clone())?)? {
-                            debug!("Joining code valadated");
+                            debug!("Joining code validated");
                             return Ok(ValidateCallbackResult::Valid)
                         } else {
                             debug!("Joining code validation failed");
                             return Ok(ValidateCallbackResult::Invalid("Joining code invalid: incorrect signature".to_string()))
-                        }
+                        }*/
                     } else {
                         return Ok(ValidateCallbackResult::Invalid("Joining code invalid payload".to_string()));
                     }

--- a/zomes/chat/src/validation.rs
+++ b/zomes/chat/src/validation.rs
@@ -27,7 +27,7 @@ pub(crate) fn joining_code(element: Element) -> ExternResult<ValidateCallbackRes
                         return Ok(ValidateCallbackResult::Invalid(format!("Joining code invalid: unexpected author ({:?})", author)))
                     }
 
-                    let _signature = mem_proof.signature().clone();
+                    // let signature = mem_proof.signature().clone();
                     if let ElementEntry::Present(_entry) = mem_proof.entry() {
                         if *mem_proof.header().author() != holo_agent {
                             debug!("Joining code not created by holo_agent");


### PR DESCRIPTION
- [x] skips membrane proof signature checking because it's failing
- [x] adds checking membrane proof agent
- [x] adds building releases from version number in cargo.toml 