### PR TITLE
Remove joining agent validation

### DIFF
--- a/dna.yaml
+++ b/dna.yaml
@@ -2,9 +2,7 @@
 manifest_version: "1"
 name: elemental-chat
 uid: 9a28aac8-337c-11eb-adc1-0Z02acw20115
-properties: 
-  skip_proof: false
-  holo_agent_override: uhCAkRHEsXSAebzKJtPsLY1XcNePAFIieFBtz2ATanlokxnSC1Kkz
+properties: ~
 zomes:
   - name: chat
     bundled: "target/wasm32-unknown-unknown/release/chat.wasm"

--- a/dna.yaml
+++ b/dna.yaml
@@ -2,7 +2,9 @@
 manifest_version: "1"
 name: elemental-chat
 uid: 9a28aac8-337c-11eb-adc1-0Z02acw20115
-properties: ~
+properties: 
+  skip_proof: false
+  holo_agent_override: uhCAkRHEsXSAebzKJtPsLY1XcNePAFIieFBtz2ATanlokxnSC1Kkz
 zomes:
   - name: chat
     bundled: "target/wasm32-unknown-unknown/release/chat.wasm"

--- a/tests/src/common.ts
+++ b/tests/src/common.ts
@@ -116,11 +116,11 @@ export const MEM_PROOF_BAD_SIG = Buffer.from("3gACrXNpZ25lZF9oZWFkZXLeAAKmaGVhZG
 
 export const MEM_PROOF_READ_ONLY = Buffer.from([0])
 
-export const installAgents = async (conductor, agentNames, memProofArray?) => {
+export const installAgents = async (conductor, agentNames, memProofArray?, holo_agent_override?) => {
 
   const admin = conductor.adminWs()
   console.log(`registering dna for: ${chatDna}`)
-  const  dnaHash = await conductor.registerDna({path: chatDna}, conductor.scenarioUID, {skip_proof: !memProofArray})
+  const  dnaHash = await conductor.registerDna({path: chatDna}, conductor.scenarioUID, {skip_proof: !memProofArray, holo_agent_override})
 
   const agents: Array<InstalledHapp> = await Promise.all(agentNames.map(
     async (agent, i) => {
@@ -137,7 +137,6 @@ export const installAgents = async (conductor, agentNames, memProofArray?) => {
       }
 
       const req = {
-        properties: {skip_proof: true},
         installed_app_id: `${agent}_chat`,
         agent_key,
         dnas: [dna]

--- a/tests/src/index.ts
+++ b/tests/src/index.ts
@@ -29,3 +29,7 @@ orchestrator.run()
 orchestrator = new Orchestrator()
 require('./membrane-proof')(orchestrator)
 orchestrator.run()
+
+orchestrator = new Orchestrator()
+require('./unique-registration-code')(orchestrator)
+orchestrator.run()

--- a/tests/src/membrane-proof.ts
+++ b/tests/src/membrane-proof.ts
@@ -69,6 +69,14 @@ module.exports = async (orchestrator) => {
       t.deepEqual(e, { type: 'error', data: { type: 'ribosome_error', data: 'Wasm error while working with Ribosome: Guest("Read only instance")' } })
     }
 
+    // Test holo_agent_override properties
+    const MEM_PROP_FOR_NEW_HOLO_AGENT = Buffer.from("3gACrXNpZ25lZF9oZWFkZXLeAAKmaGVhZGVy3gACp2NvbnRlbnTeAAekdHlwZaZDcmVhdGWmYXV0aG9yxCeEICREcSxdIB5vMom0+wtjVdw148AUiJ4UG3PYBNqeWiTGdILUqTOpdGltZXN0YW1wks5gweIkzivzEHGqaGVhZGVyX3Nlcc0BMKtwcmV2X2hlYWRlcsQnhCkks5/HpSpAL3RXYHfpjhAk8ZXayukBa4/54aur1mBaKL95vbeDqmVudHJ5X3R5cGXeAAGjQXBw3gADomlkAKd6b21lX2lkAKp2aXNpYmlsaXR53gABplB1YmxpY8CqZW50cnlfaGFzaMQnhCEkyy3pfmVBc8BkzVX5+jlnJ3TBYFrrdIdGdEMz0170ZSUTdfg9pGhhc2jEJ4QpJI+UES7dIWlQ0LcaXyirSViVBv7mCZr8GbZKBXZ7GxxR5WFvyKlzaWduYXR1cmXEQLpug6Zw3jDRuqiykCLCHrrD6q0XNxXPYe/Nq/Ec4YXY9Q3ISu9HuCC4qnAhAAOY8fcRNBIfe2WSmYfv1b2ViQalZW50cnneAAGnUHJlc2VudN4AAqplbnRyeV90eXBlo0FwcKVlbnRyecQngqRyb2xlpUFETUlOrnJlY29yZF9sb2NhdG9yqzBAaG9sby5ob3N0", 'base64')
+    try {
+      let [jack_chat_happ] = await installAgents(conductor,  ["jack"], [MEM_PROP_FOR_NEW_HOLO_AGENT], "uhCAkRHEsXSAebzKJtPsLY1XcNePAFIieFBtz2ATanlokxnSC1Kkz")
+      t.ok(true)
+    } catch(e) {
+      t.fail()
+    }
   })
 
 }

--- a/tests/src/membrane-proof.ts
+++ b/tests/src/membrane-proof.ts
@@ -15,8 +15,9 @@ module.exports = async (orchestrator) => {
     let channel_list = await alice_chat.call('chat', 'list_channels', { category: "General" });
     await awaitIntegration(alice_chat)
 
-    // this second one should fail because it will find the first membrane proof
-    try {
+    // this second one should fail because the membrane proofs are agent specific
+    // TODO: add back in when the proofs carry that agent ID
+/*    try {
       channel_list = await bobbo_chat.call('chat', 'list_channels', { category: "General" });
       t.fail()
     } catch(e) {
@@ -27,7 +28,7 @@ module.exports = async (orchestrator) => {
           data: 'The cell tried to run the initialize zomes callback but failed because Fail(ZomeName("chat"), "membrane proof for uhCkknmyjli8dQ_bh8TwZM1YzoJt4LTusPFZIohL4oEn4E3hVi1Tf already used")'
         }
       })
-    }
+    }*/
 
     // now try and install carol with a bad membrane proof
     try {

--- a/tests/src/unique-registration-code.ts
+++ b/tests/src/unique-registration-code.ts
@@ -1,0 +1,42 @@
+import { Orchestrator, Config, InstallAgentsHapps } from '@holochain/tryorama'
+import path from 'path'
+import * as _ from 'lodash'
+import { v4 as uuidv4 } from "uuid";
+import { RETRY_DELAY, RETRY_COUNT, localConductorConfig, networkedConductorConfig, installAgents, MEM_PROOF_BAD_SIG, MEM_PROOF_READ_ONLY, awaitIntegration, delay } from './common'
+
+module.exports = async (orchestrator) => {
+
+  orchestrator.registerScenario('membrane proof tests', async (s, t) => {
+    const [conductor] = await s.players([localConductorConfig])
+    const MEM_PROOF1 = Buffer.from("3gACrXNpZ25lZF9oZWFkZXLeAAKmaGVhZGVy3gACp2NvbnRlbnTeAAekdHlwZaZDcmVhdGWmYXV0aG9yxCeEICREcSxdIB5vMom0+wtjVdw148AUiJ4UG3PYBNqeWiTGdILUqTOpdGltZXN0YW1wks5gweIkzivzEHGqaGVhZGVyX3Nlcc0BMKtwcmV2X2hlYWRlcsQnhCkks5/HpSpAL3RXYHfpjhAk8ZXayukBa4/54aur1mBaKL95vbeDqmVudHJ5X3R5cGXeAAGjQXBw3gADomlkAKd6b21lX2lkAKp2aXNpYmlsaXR53gABplB1YmxpY8CqZW50cnlfaGFzaMQnhCEkyy3pfmVBc8BkzVX5+jlnJ3TBYFrrdIdGdEMz0170ZSUTdfg9pGhhc2jEJ4QpJI+UES7dIWlQ0LcaXyirSViVBv7mCZr8GbZKBXZ7GxxR5WFvyKlzaWduYXR1cmXEQLpug6Zw3jDRuqiykCLCHrrD6q0XNxXPYe/Nq/Ec4YXY9Q3ISu9HuCC4qnAhAAOY8fcRNBIfe2WSmYfv1b2ViQalZW50cnneAAGnUHJlc2VudN4AAqplbnRyeV90eXBlo0FwcKVlbnRyecQngqRyb2xlpUFETUlOrnJlY29yZF9sb2NhdG9yqzBAaG9sby5ob3N0", "base64")
+    const MEM_PROOF2 = Buffer.from("3gACrXNpZ25lZF9oZWFkZXLeAAKmaGVhZGVy3gACp2NvbnRlbnTeAAekdHlwZaZDcmVhdGWmYXV0aG9yxCeEICREcSxdIB5vMom0+wtjVdw148AUiJ4UG3PYBNqeWiTGdILUqTOpdGltZXN0YW1wks5gweIkzixIo3KqaGVhZGVyX3Nlcc0BMatwcmV2X2hlYWRlcsQnhCkkj5QRLt0haVDQtxpfKKtJWJUG/uYJmvwZtkoFdnsbHFHlYW/IqmVudHJ5X3R5cGXeAAGjQXBw3gADomlkAKd6b21lX2lkAKp2aXNpYmlsaXR53gABplB1YmxpY8CqZW50cnlfaGFzaMQnhCEkcnWUeAP9pcKJDhZ4o4O90LrmS18D+GEzbW+NDjO8Z0wf3/T9pGhhc2jEJ4QpJEtzArTCIZZC+l/TQktzXOl+xrmogg1nMIB3Ft5NjnxRZhC//KlzaWduYXR1cmXEQEAf7f2MAkMgXiD266vMoLihO0nrUSpUQIsnu8v7nZkec7OnDOQ639H6f0MfrGH3kpNetQ4j6YH1QE7X2RLrLgKlZW50cnneAAGnUHJlc2VudN4AAqplbnRyeV90eXBlo0FwcKVlbnRyecQngqRyb2xlpUFETUlOrnJlY29yZF9sb2NhdG9yqzFAaG9sby5ob3N0", "base64")
+    const MEM_PROOF3 = Buffer.from("3gACrXNpZ25lZF9oZWFkZXLeAAKmaGVhZGVy3gACp2NvbnRlbnTeAAekdHlwZaZDcmVhdGWmYXV0aG9yxCeEICREcSxdIB5vMom0+wtjVdw148AUiJ4UG3PYBNqeWiTGdILUqTOpdGltZXN0YW1wks5gweIkziyMlqqqaGVhZGVyX3Nlcc0BMqtwcmV2X2hlYWRlcsQnhCkkS3MCtMIhlkL6X9NCS3Nc6X7GuaiCDWcwgHcW3k2OfFFmEL/8qmVudHJ5X3R5cGXeAAGjQXBw3gADomlkAKd6b21lX2lkAKp2aXNpYmlsaXR53gABplB1YmxpY8CqZW50cnlfaGFzaMQnhCEkNdwxEvRlAVSYhe62yuA+hcSWSDyIGaAGmZhZhldSb6jxs+WgpGhhc2jEJ4QpJImPRZwMoQXBsQPTbolKfV3n/ULdu7UtEMxZZ+fFAWFO1p6fVKlzaWduYXR1cmXEQF9kWMKc3wf8xt65amaTRf2nozajjzPjDOPKSJsdqQ/Y0npHOXAkJiU9Fp26wfFOKEil3mxagMD5zy4HlwGRnAOlZW50cnneAAGnUHJlc2VudN4AAqplbnRyeV90eXBlo0FwcKVlbnRyecQngqRyb2xlpUFETUlOrnJlY29yZF9sb2NhdG9yqzJAaG9sby5ob3N0", "base64")
+    let [alice_chat_happ, bob_chat_happ, carol_chat_happ, daniel_chat_happ] = await installAgents(conductor,  ["alice", "bob", "carol", "daniel" ], [MEM_PROOF_READ_ONLY,  MEM_PROOF1, MEM_PROOF2, MEM_PROOF3], "uhCAkRHEsXSAebzKJtPsLY1XcNePAFIieFBtz2ATanlokxnSC1Kkz")
+    const [alice_chat] = alice_chat_happ.cells
+    const [bob_chat] = bob_chat_happ.cells
+    const [carol_chat] = carol_chat_happ.cells
+    const [daniel_chat] = daniel_chat_happ.cells
+
+    // try zome call with one read-only instance and 3 separate agents
+    let agent_stats
+    try {
+    // read-only instance:
+    agent_stats = await alice_chat.call('chat', 'agent_stats', null);
+    console.log('channel_list after ALICE : ', agent_stats);
+    
+    // read/write instances:
+    agent_stats = await bob_chat.call('chat', 'agent_stats', null);
+    console.log('agent_stats after BOB : ', agent_stats);
+
+    agent_stats = await carol_chat.call('chat', 'agent_stats', null);
+    console.log('agent_stats after CAROL : ', agent_stats);
+
+    agent_stats = await daniel_chat.call('chat', 'agent_stats', null);
+    console.log('agent_stats after DANIEL : ', agent_stats);
+    } catch (error) {
+        console.error(error)
+        t.fail()
+    }
+    t.ok(agent_stats)
+  })
+}

--- a/tests/src/unique-registration-code.ts
+++ b/tests/src/unique-registration-code.ts
@@ -1,12 +1,8 @@
-import { Orchestrator, Config, InstallAgentsHapps } from '@holochain/tryorama'
-import path from 'path'
-import * as _ from 'lodash'
-import { v4 as uuidv4 } from "uuid";
-import { RETRY_DELAY, RETRY_COUNT, localConductorConfig, networkedConductorConfig, installAgents, MEM_PROOF_BAD_SIG, MEM_PROOF_READ_ONLY, awaitIntegration, delay } from './common'
+import { localConductorConfig, installAgents, MEM_PROOF_READ_ONLY } from './common'
 
 module.exports = async (orchestrator) => {
 
-  orchestrator.registerScenario('membrane proof tests', async (s, t) => {
+  orchestrator.registerScenario('unique joining codes', async (s, t) => {
     const [conductor] = await s.players([localConductorConfig])
     const MEM_PROOF1 = Buffer.from("3gACrXNpZ25lZF9oZWFkZXLeAAKmaGVhZGVy3gACp2NvbnRlbnTeAAekdHlwZaZDcmVhdGWmYXV0aG9yxCeEICREcSxdIB5vMom0+wtjVdw148AUiJ4UG3PYBNqeWiTGdILUqTOpdGltZXN0YW1wks5gweIkzivzEHGqaGVhZGVyX3Nlcc0BMKtwcmV2X2hlYWRlcsQnhCkks5/HpSpAL3RXYHfpjhAk8ZXayukBa4/54aur1mBaKL95vbeDqmVudHJ5X3R5cGXeAAGjQXBw3gADomlkAKd6b21lX2lkAKp2aXNpYmlsaXR53gABplB1YmxpY8CqZW50cnlfaGFzaMQnhCEkyy3pfmVBc8BkzVX5+jlnJ3TBYFrrdIdGdEMz0170ZSUTdfg9pGhhc2jEJ4QpJI+UES7dIWlQ0LcaXyirSViVBv7mCZr8GbZKBXZ7GxxR5WFvyKlzaWduYXR1cmXEQLpug6Zw3jDRuqiykCLCHrrD6q0XNxXPYe/Nq/Ec4YXY9Q3ISu9HuCC4qnAhAAOY8fcRNBIfe2WSmYfv1b2ViQalZW50cnneAAGnUHJlc2VudN4AAqplbnRyeV90eXBlo0FwcKVlbnRyecQngqRyb2xlpUFETUlOrnJlY29yZF9sb2NhdG9yqzBAaG9sby5ob3N0", "base64")
     const MEM_PROOF2 = Buffer.from("3gACrXNpZ25lZF9oZWFkZXLeAAKmaGVhZGVy3gACp2NvbnRlbnTeAAekdHlwZaZDcmVhdGWmYXV0aG9yxCeEICREcSxdIB5vMom0+wtjVdw148AUiJ4UG3PYBNqeWiTGdILUqTOpdGltZXN0YW1wks5gweIkzixIo3KqaGVhZGVyX3Nlcc0BMatwcmV2X2hlYWRlcsQnhCkkj5QRLt0haVDQtxpfKKtJWJUG/uYJmvwZtkoFdnsbHFHlYW/IqmVudHJ5X3R5cGXeAAGjQXBw3gADomlkAKd6b21lX2lkAKp2aXNpYmlsaXR53gABplB1YmxpY8CqZW50cnlfaGFzaMQnhCEkcnWUeAP9pcKJDhZ4o4O90LrmS18D+GEzbW+NDjO8Z0wf3/T9pGhhc2jEJ4QpJEtzArTCIZZC+l/TQktzXOl+xrmogg1nMIB3Ft5NjnxRZhC//KlzaWduYXR1cmXEQEAf7f2MAkMgXiD266vMoLihO0nrUSpUQIsnu8v7nZkec7OnDOQ639H6f0MfrGH3kpNetQ4j6YH1QE7X2RLrLgKlZW50cnneAAGnUHJlc2VudN4AAqplbnRyeV90eXBlo0FwcKVlbnRyecQngqRyb2xlpUFETUlOrnJlY29yZF9sb2NhdG9yqzFAaG9sby5ob3N0", "base64")

--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -14,6 +14,7 @@ serde = "1.0.123"
 chrono = { version = "0.4", features = ['alloc', 'std']}
 derive_more = "0.99"
 thiserror = "1.0.20"
+hc_utils = "0"
 
 [dev-dependencies]
 #holochain = { git = "https://github.com/holochain/holochain.git", branch = "develop", features = ["test_utils"] }

--- a/zomes/chat/src/lib.rs
+++ b/zomes/chat/src/lib.rs
@@ -114,7 +114,7 @@ fn genesis_self_check(data: GenesisSelfCheckData) -> ExternResult<ValidateCallba
     if validation::skip_proof_sb(data.dna_def.properties.clone()) {
         return Ok(ValidateCallbackResult::Valid);
     }
-    let host_agent = validation::holo_agent(data.dna_def.properties)?;
+    let holo_agent_key = validation::holo_agent(data.dna_def.properties)?;
     validation::joining_code(data.agent_key, data.membrane_proof, holo_agent_key)
 }
 #[hdk_extern]

--- a/zomes/chat/src/lib.rs
+++ b/zomes/chat/src/lib.rs
@@ -111,10 +111,11 @@ fn init(_: ()) -> ExternResult<InitCallbackResult> {
 
 #[hdk_extern]
 fn genesis_self_check(data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
-    if validation::skip_proof_sb(data.dna_def.properties) {
+    if validation::skip_proof_sb(data.dna_def.properties.clone()) {
         return Ok(ValidateCallbackResult::Valid);
     }
-    validation::joining_code(data.agent_key, data.membrane_proof)
+    let host_agent = validation::holo_agent(data.dna_def.properties)?;
+    validation::joining_code(data.agent_key, data.membrane_proof, host_agent)
 }
 #[hdk_extern]
 fn create_channel(channel_input: ChannelInput) -> ExternResult<ChannelData> {

--- a/zomes/chat/src/lib.rs
+++ b/zomes/chat/src/lib.rs
@@ -114,7 +114,7 @@ fn genesis_self_check(data: GenesisSelfCheckData) -> ExternResult<ValidateCallba
     if validation::skip_proof_sb(data.dna_def.properties) {
         return Ok(ValidateCallbackResult::Valid);
     }
-    validation::joining_code(data.agent_key, data.membrane_proof, true)
+    validation::joining_code(data.agent_key, data.membrane_proof)
 }
 #[hdk_extern]
 fn create_channel(channel_input: ChannelInput) -> ExternResult<ChannelData> {

--- a/zomes/chat/src/lib.rs
+++ b/zomes/chat/src/lib.rs
@@ -111,10 +111,10 @@ fn init(_: ()) -> ExternResult<InitCallbackResult> {
 
 #[hdk_extern]
 fn genesis_self_check(data: GenesisSelfCheckData) -> ExternResult<ValidateCallbackResult> {
-    if validation::skip_proof_sb(data.dna_def.properties.clone()) {
+    if validation::skip_proof_sb(&data.dna_def.properties) {
         return Ok(ValidateCallbackResult::Valid);
     }
-    let holo_agent_key = validation::holo_agent(data.dna_def.properties)?;
+    let holo_agent_key = validation::holo_agent(&data.dna_def.properties)?;
     validation::joining_code(data.agent_key, data.membrane_proof, holo_agent_key)
 }
 #[hdk_extern]

--- a/zomes/chat/src/lib.rs
+++ b/zomes/chat/src/lib.rs
@@ -115,7 +115,7 @@ fn genesis_self_check(data: GenesisSelfCheckData) -> ExternResult<ValidateCallba
         return Ok(ValidateCallbackResult::Valid);
     }
     let host_agent = validation::holo_agent(data.dna_def.properties)?;
-    validation::joining_code(data.agent_key, data.membrane_proof, host_agent)
+    validation::joining_code(data.agent_key, data.membrane_proof, holo_agent_key)
 }
 #[hdk_extern]
 fn create_channel(channel_input: ChannelInput) -> ExternResult<ChannelData> {

--- a/zomes/chat/src/validation.rs
+++ b/zomes/chat/src/validation.rs
@@ -43,7 +43,7 @@ pub(crate) fn is_read_only_proof(mem_proof: &MembraneProof) -> bool {
 }
 
 /// Validate joining code from the membrane_proof
-pub(crate) fn joining_code(author: AgentPubKey, membrane_proof: Option<MembraneProof>, genesis: bool) -> ExternResult<ValidateCallbackResult> {
+pub(crate) fn joining_code(_author: AgentPubKey, membrane_proof: Option<MembraneProof>) -> ExternResult<ValidateCallbackResult> {
 
     // This is a hard coded holo agent public key
     let holo_agent = AgentPubKey::try_from("uhCAkfzycXcycd-OS6HQHvhTgeDVjlkFdE2-XHz-f_AC_5xelQX1N").unwrap();
@@ -70,32 +70,12 @@ pub(crate) fn joining_code(author: AgentPubKey, membrane_proof: Option<MembraneP
             if let ElementEntry::Present(_entry) = e {
                 let signature = mem_proof.signature().clone();
                 if verify_signature(holo_agent.clone(), signature, mem_proof.header())? {
+                    // TODO: check that the joining code has the correct author key in it
+                    // once this is added to the registration flow, e.g.:
+                    // if mem_proof.payload().agent != author {
+                    //    return Ok(ValidateCallbackResult::Invalid("Joining code invalid: incorrect agent key".to_string()))
+                    // }
                     trace!("Joining code validated");
-                    if !genesis {
-                        let code = joining_code_value(&mem_proof);
-                        trace!("Checking for joining code: {}", code);
-                        let path = Path::from(code.clone());
-                        let path_entry_hash = path.hash()?;
-                        let maybe_details = get_details( path_entry_hash.clone(), GetOptions::default())?;
-                        match maybe_details {
-                            Some(details) => {
-                                if let Details::Entry(e) = details {
-                                    let mut deets:Vec<(Timestamp, AgentPubKey)> = e.headers.iter().map(|h| {
-                                        let header = h.header();
-                                        (header.timestamp(), header.author().clone())
-                                    }).collect();
-                                    deets.sort_by(|a, b| a.0.cmp(&b.0));
-                                    if deets[0].1 != author {
-                                        return Ok(ValidateCallbackResult::Invalid(format!("Earliest joining code for {} was by {} not {} as expected", code, deets[0].1, author )))
-                                    }
-                                }
-                            }
-                            None => {
-                                trace!("Unresolved, waiting...");
-                                return Ok(ValidateCallbackResult::UnresolvedDependencies(vec![(path_entry_hash).into()]))
-                            }
-                        };
-                    }
                     return Ok(ValidateCallbackResult::Valid)
                 } else {
                     trace!("Joining code validation failed: incorrect signature");
@@ -126,7 +106,7 @@ pub(crate) fn common_validatation(data: ValidateData) -> ExternResult<ValidateCa
                             Some(element_pkg) => {
                                 match element_pkg.signed_header().header() {
                                     Header::AgentValidationPkg(pkg) => {
-                                        return joining_code(pkg.author.clone(), pkg.membrane_proof.clone(), false)
+                                        return joining_code(pkg.author.clone(), pkg.membrane_proof.clone())
                                     }
                                     _ => return Ok(ValidateCallbackResult::Invalid("No Agent Validation Pkg found".to_string()))
                                 }

--- a/zomes/chat/src/validation.rs
+++ b/zomes/chat/src/validation.rs
@@ -8,8 +8,8 @@ pub struct Props {
     pub holo_agent_override: Option<WrappedAgentPubKey>,
 }
 
-pub(crate) fn skip_proof_sb(encoded_props: SerializedBytes) -> bool {
-    let maybe_props = Props::try_from(encoded_props);
+pub(crate) fn skip_proof_sb(encoded_props: &SerializedBytes) -> bool {
+    let maybe_props = Props::try_from(encoded_props.to_owned());
     if let Ok(props) = maybe_props {
         return props.skip_proof;
     }
@@ -19,7 +19,7 @@ pub(crate) fn skip_proof_sb(encoded_props: SerializedBytes) -> bool {
 // This is useful for test cases where we don't want to provide a membrane proof
 pub(crate) fn skip_proof() -> bool {
     if let Ok(info) = zome_info() {
-        return skip_proof_sb(info.properties);
+        return skip_proof_sb(&info.properties);
     }
     return false
 }
@@ -43,8 +43,8 @@ pub(crate) fn is_read_only_proof(mem_proof: &MembraneProof) -> bool {
     b == &[0]
 }
 // zome_info()?.properties
-pub(crate) fn holo_agent(encoded_props: SerializedBytes) -> ExternResult<AgentPubKey> {
-    let maybe_props = Props::try_from(encoded_props);
+pub(crate) fn holo_agent(encoded_props: &SerializedBytes) -> ExternResult<AgentPubKey> {
+    let maybe_props = Props::try_from(encoded_props.to_owned());
     if let Ok(props) = maybe_props {
         if let Some(a) = props.holo_agent_override {
             return Ok(AgentPubKey::try_from(a).unwrap())
@@ -115,7 +115,7 @@ pub(crate) fn common_validatation(data: ValidateData) -> ExternResult<ValidateCa
                             Some(element_pkg) => {
                                 match element_pkg.signed_header().header() {
                                     Header::AgentValidationPkg(pkg) => {
-                                        return joining_code(pkg.author.clone(), pkg.membrane_proof.clone(), holo_agent(zome_info()?.properties)?)
+                                        return joining_code(pkg.author.clone(), pkg.membrane_proof.clone(), holo_agent(&zome_info()?.properties)?)
                                     }
                                     _ => return Ok(ValidateCallbackResult::Invalid("No Agent Validation Pkg found".to_string()))
                                 }

--- a/zomes/chat/src/validation.rs
+++ b/zomes/chat/src/validation.rs
@@ -50,14 +50,12 @@ pub(crate) fn holo_agent(encoded_props: SerializedBytes) -> ExternResult<AgentPu
             return Ok(AgentPubKey::try_from(a).unwrap())
         }
     }
+    // This is a hard coded holo agent public key
     return Ok(AgentPubKey::try_from("uhCAkfzycXcycd-OS6HQHvhTgeDVjlkFdE2-XHz-f_AC_5xelQX1N").unwrap())
 }
 
 /// Validate joining code from the membrane_proof
 pub(crate) fn joining_code(_author: AgentPubKey, membrane_proof: Option<MembraneProof>, holo_agent: AgentPubKey) -> ExternResult<ValidateCallbackResult> {
-
-    // This is a hard coded holo agent public key
-    // let holo_agent = AgentPubKey::try_from("uhCAkfzycXcycd-OS6HQHvhTgeDVjlkFdE2-XHz-f_AC_5xelQX1N").unwrap();
     match membrane_proof {
         Some(mem_proof) => {
             if is_read_only_proof(&mem_proof) {


### PR DESCRIPTION
Agent key will replace record-locator in membrane_proof which obviates need for duplicate joining code check, which is also breaks with must_get.

This PR removes the check during agent validation (though it remains during init).