### PR TITLE
nix-shell: fix typo in binaryen package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,6 +22,6 @@ let
 in nixpkgs.mkShell {
   inputsFrom = [ holonix.main ];
   buildInputs = with nixpkgs; [
-    binaryien
+    binaryen
   ];
 }


### PR DESCRIPTION
@alastairong 