### PR TITLE
Fix joining code crate for hdk 101

### DIFF
--- a/crates/joining_code/Cargo.toml
+++ b/crates/joining_code/Cargo.toml
@@ -9,7 +9,6 @@ name = "hc_joining_code"
 crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
-hdk = "0.0.101-alpha.0"
+hdk = "0.0.101"
 serde = "1.0.123"
 derive_more = "0.99"
-holo_hash = "0.0.2-alpha.1"

--- a/crates/joining_code/src/props.rs
+++ b/crates/joining_code/src/props.rs
@@ -1,5 +1,5 @@
 use hdk::prelude::*;
-use self::holo_hash::AgentPubKeyB64;
+use hdk::prelude::holo_hash::AgentPubKeyB64;
 
 #[derive(Debug, Serialize, Deserialize, SerializedBytes, Clone)]
 pub struct Props {


### PR DESCRIPTION
Without this change, I can't compile on elemental-chess. I can update the chat zome as well if you want, eventually it will need to be done.

You don't need to merge this right now, just pointing at it from the elemental-chess repo.