### PR TITLE
github/workflows: set up cachix-action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,10 @@ jobs:
         set -xe
         mkdir -p ~/.config/nix/
         cp ./.github/nix.conf ~/.config/nix/
+    - uses: cachix/cachix-action@v10
+      with:
+        name: holochain-ci
+        authToken: '${{ secrets.CACHIX_HOLOCHAIN_CI }}'
     - name: Prepare Nix environment
       run: nix-shell --command "echo Completed"
     - name: Run all tests


### PR DESCRIPTION
This configures github actions to use cachix, which will greatly speed
up runs whenever the same holochain revision is reused.
