### PR TITLE
Fix read only membrane proof

### DIFF
--- a/crates/joining_code/src/init.rs
+++ b/crates/joining_code/src/init.rs
@@ -1,12 +1,15 @@
 use hdk::prelude::*;
 
-use crate::joining_code;
+use crate::{is_read_only_proof, joining_code};
 
 pub fn init_validate_and_create_joining_code() -> ExternResult<InitCallbackResult> {
     let elements = &query(ChainQueryFilter::new().header_type(HeaderType::AgentValidationPkg))?;
     if let Header::AgentValidationPkg(h) = elements[0].header() {
         match &h.membrane_proof {
             Some(mem_proof) => {
+                if is_read_only_proof(&mem_proof) {
+                    return Ok(InitCallbackResult::Pass);
+                };
                 let mem_proof = match Element::try_from(mem_proof.clone()) {
                     Ok(m) => m,
                     Err(_e) => {


### PR DESCRIPTION
Surprised this hasn't been caught yet. Read only EC simply didn't initialize because the memproof logic had a bug.