### PR TITLE
Converts channel uuid to u128 for shrinking path length

### DIFF
--- a/zomes/chat/Cargo.toml
+++ b/zomes/chat/Cargo.toml
@@ -17,6 +17,7 @@ serde = "1.0"
 thiserror = "1.0"
 hc_utils = "=0.0.115"
 holo_hash = { version = "=0.0.12", features = ["encoding"] }
+uuid = "0.8.2"
 
 [dev-dependencies]
 # holochain = "=0.0.117"

--- a/zomes/chat/src/entries/channel.rs
+++ b/zomes/chat/src/entries/channel.rs
@@ -2,6 +2,7 @@ use crate::timestamp::Timestamp;
 use hdk::{hash_path::path::Component, prelude::*};
 use uuid::Uuid;
 pub mod handlers;
+use std;
 
 /// The actual channel data that is saved into the DHT
 /// This is the actual name of the channel that
@@ -64,7 +65,7 @@ pub struct ChannelList {
 impl From<Channel> for Path {
     fn from(c: Channel) -> Self {
         let u = Uuid::parse_str(&c.uuid).unwrap();
-        let path = vec![Component::from(c.category), Component::from(u.to_u128_le().to_le_bytes().to_vec())];
+        let path = vec![Component::from(c.category.as_bytes().to_vec()), Component::from(u.to_u128_le().to_le_bytes().to_vec())];
         Path::from(path)
     }
 }
@@ -76,8 +77,9 @@ impl TryFrom<&Path> for Channel {
         let path: &Vec<_> = p.as_ref();
         let u128 = u128::from_le_bytes(path[1].as_ref().try_into().expect("wrong length"));
         let u = Uuid::from_u128(u128);
+        let c: String = std::str::from_utf8(path[0].as_ref()).expect("bad string").to_string();
         let channel = Channel {
-            category: String::try_from(&path[0])?,
+            category: String::try_from(c)?,
             uuid: u.to_string(),
         };
         Ok(channel)

--- a/zomes/chat/src/entries/channel.rs
+++ b/zomes/chat/src/entries/channel.rs
@@ -1,5 +1,6 @@
 use crate::timestamp::Timestamp;
 use hdk::{hash_path::path::Component, prelude::*};
+use uuid::Uuid;
 pub mod handlers;
 
 /// The actual channel data that is saved into the DHT
@@ -62,7 +63,8 @@ pub struct ChannelList {
 
 impl From<Channel> for Path {
     fn from(c: Channel) -> Self {
-        let path = vec![Component::from(c.category), Component::from(c.uuid)];
+        let u = Uuid::parse_str(&c.uuid).unwrap();
+        let path = vec![Component::from(c.category), Component::from(u.to_u128_le().to_le_bytes().to_vec())];
         Path::from(path)
     }
 }
@@ -72,9 +74,11 @@ impl TryFrom<&Path> for Channel {
 
     fn try_from(p: &Path) -> Result<Self, Self::Error> {
         let path: &Vec<_> = p.as_ref();
+        let u128 = u128::from_le_bytes(path[1].as_ref().try_into().expect("wrong length"));
+        let u = Uuid::from_u128(u128);
         let channel = Channel {
             category: String::try_from(&path[0])?,
-            uuid: String::try_from(&path[1])?,
+            uuid: u.to_string(),
         };
         Ok(channel)
     }

--- a/zomes/chat/src/entries/channel/handlers.rs
+++ b/zomes/chat/src/entries/channel/handlers.rs
@@ -4,6 +4,7 @@ use crate::{
     error::ChatResult,
 };
 use hdk::prelude::*;
+use hdk::hash_path::path::Component;
 use link::Link;
 use std::collections::HashMap;
 
@@ -37,10 +38,14 @@ pub(crate) fn create_channel(channel_input: ChannelInput) -> ChatResult<ChannelD
     Ok(ChannelData::new(entry, info))
 }
 
+fn category_path(category: String) -> Path {
+    let path = vec![Component::from(category.as_bytes().to_vec())];
+    Path::from(path)
+}
+
 pub(crate) fn list_channels(list_channels_input: ChannelListInput) -> ChatResult<ChannelList> {
     // Get the category path
-    let path = Path::from(list_channels_input.category);
-
+    let path= category_path(list_channels_input.category);
     // Get any channels on this path
     let links = path.children()?;
     let mut channels = Vec::with_capacity(links.len());
@@ -110,7 +115,8 @@ pub(crate) fn list_channels(list_channels_input: ChannelListInput) -> ChatResult
 
 // Note: This function can get very heavy
 pub(crate) fn channel_stats(list_channels_input: ChannelListInput) -> ChatResult<(usize, usize)> {
-    let channel_path = Path::from(list_channels_input.category);
+    let channel_path = category_path(list_channels_input.category);
+
     let channel_links = channel_path.children()?;
     Ok((channel_links.len(), 0))
 }


### PR DESCRIPTION
link path was using the channel UUID as a string which is quite long.  This PR converts to using the bytes of the u128 directly in the path.